### PR TITLE
Move test external-data declaration from main library

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,13 @@
 from stactools.testing import TestData
 
-test_data = TestData(__file__)
+_external_data = {
+    'AST_L1T_00305032000040446_20150409135350_78838.hdf': {
+        'url':
+        ('https://ai4epublictestdata.blob.core.windows.net/'
+         'stactools/aster/AST_L1T_00305032000040446_20150409135350_78838.zip'),
+        'compress':
+        'zip'
+    }
+}
+
+test_data = TestData(__file__, _external_data)


### PR DESCRIPTION
When stac-utils/stactools#137 is resolved, merge this to fix one of the tests.