### PR TITLE
Add "update geometry" command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    stactools >= 0.4.0
+    stactools >= 0.4.2
 
 [options.packages.find]
 where = src

--- a/src/stactools/aster/constants.py
+++ b/src/stactools/aster/constants.py
@@ -126,3 +126,5 @@ UPPER_LEFT_QUAD_CLOUD_COVER = "aster:upper_left_quad_cloud_cover"
 UPPER_RIGHT_QUAD_CLOUD_COVER = "aster:upper_right_quad_cloud_cover"
 LOWER_LEFT_QUAD_CLOUD_COVER = "aster:lower_left_quad_cloud_cover"
 LOWER_RIGHT_QUAD_CLOUD_COVER = "aster:lower_right_quad_cloud_cover"
+
+NO_DATA = 0


### PR DESCRIPTION
This ends up being pretty simple, the harder lift was in https://github.com/stac-utils/stactools/pull/355. Includes an API call and a CLI utility.

I wanted to set a default `simplify_tolerance`, since the produced geometry is quite large by default:

```sh
$ stac aster update-geometry https://planetarycomputer.microsoft.com/api/stac/v1/collections/aster-l1t/items/AST_L1T_00310012006175412_20150516104359 > AST_L1T_00310012006175412_20150516104359-simplified.json
$ du -h AST_L1T_00310012006175412_20150516104359-simplified.json 
136K    AST_L1T_00310012006175412_20150516104359-simplified.json
```

However, there's some tradeoffs, as a (e.g.) ~90m simplify tolerance ends up being much smaller, but drops areas that include some VNIR pixels:

```sh
$ stac aster update-geometry --simplify-tolerance 0.001 https://planetarycomputer.microsoft.com/api/stac/v1/collections/aster-l1t/items/AST_L1T_00310012006175412_20150516104359 > AST_L1T_00310012006175412_20150516104359-simplified.json
$ du -h AST_L1T_00310012006175412_20150516104359-simplified.json 
 12K    AST_L1T_00310012006175412_20150516104359-simplified.json
```

Full resolution is red, simplified to 0.001 is in blue, and overlap is in green:

![simplify](https://user-images.githubusercontent.com/58314/190497570-584cfa25-b7d2-4bea-9057-101b1a7e2abb.png)

My instinct is to _not_ set a default in this packages, and let downstream users (e.g. Planetary Computer) choose their tolerance level.

## Draft

I've marked this as draft because it depends on https://github.com/stac-utils/stactools/pull/355, which is currently unreleased. Once that is released, we can update this PR to depend on that version.